### PR TITLE
Patch/nosegae 0 4 0

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task :venv => ['requirements.txt', 'venv/bin/activate'] do
 end
 
 task :test => [:venv] do
-  execute_command('. venv/bin/activate; nosetests -v -s --with-gae --without-sandbox ./tests/unit ./tests/func/')
+  execute_command('. venv/bin/activate; nosetests -v -s --with-gae ./tests/unit ./tests/func/')
 end
 
 task :build => [:clean, :venv, :test] do

--- a/tests/func/score/test_score.py
+++ b/tests/func/score/test_score.py
@@ -4,7 +4,6 @@ import webtest
 from random import randint
 
 from google.appengine.ext import ndb
-from google.appengine.ext import testbed
 
 import main
 from models.datastore.score_ds import ScoreModel
@@ -13,16 +12,11 @@ from models.score import Score
 class TestScoreHandler(unittest.TestCase):
     def setUp(self):
         self.app = webtest.TestApp(main.application)
-        self.testbed = testbed.Testbed()
-        self.testbed.activate()
-        self.testbed.init_datastore_v3_stub()
         self.testbed.init_memcache_stub()
+        self.testbed.init_datastore_v3_stub()
 
         self.year = 2014
         self.week = randint(1, 17)
-
-    def tearDown(self):
-        self.testbed.deactivate()
 
     def generate_score_data(self, year=1990, week=0):
         test_data = self._random_test_data(year=year, week=week)

--- a/tests/func/score/test_scores.py
+++ b/tests/func/score/test_scores.py
@@ -8,7 +8,6 @@ from random import randint
 
 from google.appengine.api import urlfetch
 from google.appengine.ext import ndb
-from google.appengine.ext import testbed
 
 
 import main
@@ -17,17 +16,12 @@ from models.datastore.score_ds import ScoreModel
 class TestScoresHandler(unittest.TestCase):
     def setUp(self):
         self.app = webtest.TestApp(main.application)
-        self.testbed = testbed.Testbed()
-        self.testbed.activate()
         self.testbed.init_datastore_v3_stub()
         self.testbed.init_memcache_stub()
         self.testbed.init_urlfetch_stub()
 
         self.year = 2014
         self.week = randint(1, 17)
-
-    def tearDown(self):
-        self.testbed.deactivate()
 
     def _create_mock(self, content=''):
         class UrlMock(object):

--- a/tests/func/spread/test_spread.py
+++ b/tests/func/spread/test_spread.py
@@ -3,8 +3,6 @@ import unittest
 import webtest
 from random import randint
 
-from google.appengine.ext import testbed
-
 import main
 from models.datastore.spread_ds import SpreadModel
 from models.spread import Spread
@@ -12,15 +10,11 @@ from models.spread import Spread
 class TestSpreadHandler(unittest.TestCase):
     def setUp(self):
         self.app = webtest.TestApp(main.application)
-        self.testbed = testbed.Testbed()
-        self.testbed.activate()
+        self.testbed.init_memcache_stub()
         self.testbed.init_datastore_v3_stub()
 
         self.year = 2014
         self.week = randint(1, 17)
-
-    def tearDown(self):
-        self.testbed.deactivate()
 
     def _prepopulate_datastore(self, year=1990, week=0):
         parent_key = Spread()._generate_key(year=year, week=week)

--- a/tests/func/spread/test_spreads.py
+++ b/tests/func/spread/test_spreads.py
@@ -3,8 +3,6 @@ import unittest
 import webtest
 from random import randint
 
-from google.appengine.ext import testbed
-
 import main
 from models.datastore.spread_ds import SpreadModel
 from models.spread import Spread
@@ -12,15 +10,11 @@ from models.spread import Spread
 class TestSpreadsHandler(unittest.TestCase):
     def setUp(self):
         self.app = webtest.TestApp(main.application)
-        self.testbed = testbed.Testbed()
-        self.testbed.activate()
+        self.testbed.init_memcache_stub()
         self.testbed.init_datastore_v3_stub()
 
         self.year = 2014
         self.week = randint(1, 17)
-
-    def tearDown(self):
-        self.testbed.deactivate()
 
 
     def generate_spread_data(self, year=2014, week=0, count=1):

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -2,7 +2,6 @@ from random import randint
 import unittest
 
 from google.appengine.ext import ndb
-from google.appengine.ext import testbed
 
 from models.datastore.spread_ds import SpreadModel
 from models.spread import Spread
@@ -10,16 +9,13 @@ from models.spread import Spread
 
 class TestSpread(unittest.TestCase):
     def setUp(self):
-        self.testbed = testbed.Testbed()
-        self.testbed.activate()
+        self.testbed.init_memcache_stub()
         self.testbed.init_datastore_v3_stub()
 
         self.year = 2014
         self.week = randint(1, 17)
         self.expected_count = randint(2, 16)
 
-    def tearDown(self):
-        self.testbed.deactivate()
 
     def _generate_data(self, year=2014, week=0, count=1):
         game_id = randint(1000, 9000)

--- a/tests/unit/test_spread_ds.py
+++ b/tests/unit/test_spread_ds.py
@@ -2,18 +2,14 @@ import unittest
 from random import randint
 
 from google.appengine.ext import ndb
-from google.appengine.ext import testbed
 
 from models.datastore.spread_ds import SpreadModel
 
 class TestSpread(unittest.TestCase):
     def setUp(self):
-        self.testbed = testbed.Testbed()
-        self.testbed.activate()
+        self.testbed.init_memcache_stub()
         self.testbed.init_datastore_v3_stub()
 
-    def tearDown(self):
-        self.testbed.deactivate()
 
     def test_basic(self):
         year = 2014

--- a/wercker.yml
+++ b/wercker.yml
@@ -37,12 +37,12 @@ build:
     - script:
         name: execute unit tests
         code: |
-          nosetests -v --with-gae --without-sandbox --gae-lib-root=$GOOGLE_APPENGINE ./tests/unit/
+          nosetests -v --with-gae --gae-lib-root=$GOOGLE_APPENGINE ./tests/unit/
 
     - script:
         name: execute functional tests
         code: |
-          nosetests -v --with-gae --without-sandbox --gae-lib-root=$GOOGLE_APPENGINE ./tests/func/
+          nosetests -v --with-gae --gae-lib-root=$GOOGLE_APPENGINE ./tests/func/
 
 deploy:
   steps:


### PR DESCRIPTION
NoseGAE 0.4.0 dropped support for `--without-sandbox` option. NoseGAE now injects a `testbed` object into the test cases.

Tests were updated to use this injected `testbed` object:
* Memcache was initialized whenever it was implied to be used (e.g., with datastore operations)
* Importing of the `testbed` library were dropped, since NoseGAE does it passively.