### PR TITLE
Cron API endpoint to be GET instead of POST

### DIFF
--- a/controllers/cron.py
+++ b/controllers/cron.py
@@ -11,7 +11,7 @@ class CronScoreHandler(webapp2.RequestHandler):
         self.scoreboard = Scoreboard()
         super(CronScoreHandler, self).__init__(*args, **kwargs)
 
-    def post(self):
+    def get(self):
         current_week = self.schedule.week()
         current_season = self.schedule.season_year()
         result = self.scoreboard.fetch(year=current_season, week=current_week)

--- a/tests/func/cron/test_cron.py
+++ b/tests/func/cron/test_cron.py
@@ -68,7 +68,7 @@ class TestCronScoreHandler(unittest.TestCase):
         mock_schedule.return_value.week.return_value = expected_week
         mock_schedule.return_value.season_year.return_value = expected_year
 
-        response = self.app.post(endpoint)
+        response = self.app.get(endpoint)
         self.assertEqual(response.status_int, 201)
         # Check mocks
         mock_urlfetch.fetch.assert_called_with(url=expected_url)


### PR DESCRIPTION
Due to the limitations of the cron task, the API endpoint for updating the scores must be a GET operation instead of a POST operation.
